### PR TITLE
feat(core): sort SWC nodes by default

### DIFF
--- a/swcgeom/core/swc_utils/io.py
+++ b/swcgeom/core/swc_utils/io.py
@@ -30,7 +30,7 @@ def read_swc(
     swc_file: PathOrIO,
     extra_cols: Iterable[str] | None = None,
     fix_roots: Literal["somas", "nearest", False] = False,
-    sort_nodes: bool = False,
+    sort_nodes: bool = True,
     reset_index: bool = True,
     *,
     encoding: Literal["detect"] | str = "utf-8",
@@ -44,12 +44,12 @@ def read_swc(
         extra_cols: Read more cols in swc file.
         fix_roots: Fix multiple roots.
         sort_nodes: Sort the indices of neuron tree.
-            After sorting the nodes, the index for each parent are always less than
-            that of its children.
+            After sorting the nodes, the index for each parent are always less than that of its children, default to
+            True.
         reset_index: Reset node index to start with zero.
-            DO NOT set to false if you are not sure what will happened.
+            DO NOT set to false if you are not sure what will happened, default to True.
         encoding: The name of the encoding used to decode the file.
-            If is `detect`, we will try to detect the character encoding.
+            If is `detect`, we will try to detect the character encoding, default to "utf-8".
 
     Returns:
         df: ~pandas.DataFrame


### PR DESCRIPTION
Enable the `sort_nodes` option for the `read_swc` function by default. This also affects `Tree.from_swc`, `Tree.from_eswc`, `Population.from_swc`, and many other related functions.

This option is necessary because some SWC files do not have continuous IDs, which is a critical assumption in our library. Previously, it was disabled by default for performance reasons. However, we’ve received many bug reports that were difficult to track down. To improve usability, we are now enabling this option by default, hoping it will prevent further issues.

This change should not break any existing scripts, unless they explicitly rely on the original ID order (which they should NOT). We also hope to improve the performance of this option in the future.